### PR TITLE
refactor(web): deduplicate inline type definitions

### DIFF
--- a/apps/web/src/components/dashboard/graph-dashboard.tsx
+++ b/apps/web/src/components/dashboard/graph-dashboard.tsx
@@ -27,31 +27,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet"
-
-// Database Types
-type DBNode = {
-  id: string
-  user_id: string
-  url: string
-  title: string
-  summary: string
-  raw_text: string
-}
-
-type DBEdge = {
-  id: string
-  source_id: string
-  target_id: string
-  relation_type: string
-  weight: number
-}
-
-type DBEntity = {
-  id: string
-  name: string
-  type: string
-  user_id: string
-}
+import type { DBNode, DBEntity, DBEdge } from '@/lib/types'
 
 interface GraphDashboardProps {
   initialNodes: DBNode[]

--- a/apps/web/src/components/dashboard/node-detail-sheet.tsx
+++ b/apps/web/src/components/dashboard/node-detail-sheet.tsx
@@ -12,32 +12,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { ExternalLink, Link as LinkIcon, Tag, Clock, Network, FileText } from 'lucide-react'
-
-type DBNode = {
-  id: string
-  user_id: string
-  url: string
-  title: string
-  summary: string
-  raw_text: string
-  created_at: string
-}
-
-type DBEntity = {
-  id: string
-  name: string
-  type: string
-  user_id: string
-  node_id: string | null
-}
-
-type DBEdge = {
-  id: string
-  source_id: string
-  target_id: string
-  relation_type: string
-  weight: number
-}
+import type { DBNode, DBEntity, DBEdge } from '@/lib/types'
 
 interface NodeDetailSheetProps {
   node: DBNode


### PR DESCRIPTION
## Problem\n
ode-detail-sheet.tsx and graph-dashboard.tsx each defined their own inline copies of DBNode, DBEntity, and DBEdge types (51 lines total), drifting from the canonical source at @/lib/types.ts.\n\nCloses #10 (part of Epic #4).\n\n## Solution\n- Deleted all inline type declarations from both files.\n- Added import type { DBNode, DBEntity, DBEdge } from '@/lib/types' in each.\n- Net change: **+2 insertions, -51 deletions**.\n\n## Testing\n- 
ext build — compiled successfully (exit code 0), TypeScript check passed, all 15 pages generated.\n- No runtime behaviour changes — these are type-only imports.