### PR TITLE
feat(web): add dashboard stats header and redesign node cards

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -8,6 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Button } from '@/components/ui/button'
 import NavTab from '@/components/dashboard/nav-tab'
 import AuthProvider from '@/components/providers/auth-provider'
+import DashboardStats from '@/components/dashboard/dashboard-stats'
 
 export default async function DashboardLayout({
   children,
@@ -23,6 +24,14 @@ export default async function DashboardLayout({
   if (!user) {
     return redirect('/login')
   }
+
+  // Fetch count of reviews due today or earlier for stats bar
+  const now = new Date().toISOString()
+  const { count: dueCount } = await supabase
+    .from('reviews')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', user.id)
+    .lte('next_review_date', now)
 
   const initials = (user.email ?? '?')
     .split('@')[0]
@@ -87,6 +96,9 @@ export default async function DashboardLayout({
             </div>
           </div>
         </header>
+
+        {/* Stats Bar */}
+        <DashboardStats dueCount={dueCount ?? 0} />
 
         {/* Main Content */}
         <main className="flex-1 overflow-hidden">{children}</main>

--- a/apps/web/src/components/dashboard/dashboard-stats.tsx
+++ b/apps/web/src/components/dashboard/dashboard-stats.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { Brain, Tag, Network, GraduationCap } from 'lucide-react'
+import { useNodesStore } from '@/stores/nodes-store'
+
+interface DashboardStatsProps {
+  /** Number of review cards due today — fetched server-side, passed as prop */
+  dueCount: number
+}
+
+interface StatCardProps {
+  icon: React.ReactNode
+  label: string
+  value: number
+  gradient: string
+}
+
+function StatCard({ icon, label, value, gradient }: StatCardProps) {
+  return (
+    <div className="group flex items-center gap-3 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm px-4 py-3 transition-all duration-300 hover:border-primary/30 hover:shadow-md hover:shadow-primary/5">
+      <div
+        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${gradient} shadow-sm`}
+      >
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <p className="text-xl font-bold tracking-tight animate-nexus-fade-in">
+          {value.toLocaleString()}
+        </p>
+        <p className="text-xs text-muted-foreground truncate">{label}</p>
+      </div>
+    </div>
+  )
+}
+
+export default function DashboardStats({ dueCount }: DashboardStatsProps) {
+  const nodes = useNodesStore((s) => s.nodes)
+  const entities = useNodesStore((s) => s.entities)
+  const edges = useNodesStore((s) => s.edges)
+
+  const stats: StatCardProps[] = [
+    {
+      icon: <Brain className="h-4.5 w-4.5 text-white" />,
+      label: 'Nodes Captured',
+      value: nodes.length,
+      gradient:
+        'bg-gradient-to-br from-[oklch(0.637_0.237_275)] to-[oklch(0.7_0.2_310)]',
+    },
+    {
+      icon: <Tag className="h-4.5 w-4.5 text-white" />,
+      label: 'Entities Extracted',
+      value: entities.length,
+      gradient:
+        'bg-gradient-to-br from-[oklch(0.65_0.2_180)] to-[oklch(0.6_0.18_200)]',
+    },
+    {
+      icon: <Network className="h-4.5 w-4.5 text-white" />,
+      label: 'Connections',
+      value: edges.length,
+      gradient:
+        'bg-gradient-to-br from-[oklch(0.7_0.2_310)] to-[oklch(0.65_0.22_340)]',
+    },
+    {
+      icon: <GraduationCap className="h-4.5 w-4.5 text-white" />,
+      label: 'Due for Review',
+      value: dueCount,
+      gradient:
+        'bg-gradient-to-br from-[oklch(0.75_0.15_60)] to-[oklch(0.7_0.18_40)]',
+    },
+  ]
+
+  return (
+    <div className="border-b border-border/50 bg-background/60 backdrop-blur-sm">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 px-6 py-3 stagger-children">
+        {stats.map((stat) => (
+          <StatCard key={stat.label} {...stat} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/dashboard/node-feed.tsx
+++ b/apps/web/src/components/dashboard/node-feed.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { FeedEmptyState } from './empty-states'
 import { Separator } from '@/components/ui/separator'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   Sheet,
   SheetContent,
@@ -24,6 +25,8 @@ import {
   Search,
   Trash2,
   Loader2,
+  ChevronDown,
+  ChevronUp,
 } from 'lucide-react'
 import { toast } from 'sonner'
 
@@ -73,6 +76,15 @@ function getDomain(url: string): string {
   }
 }
 
+function getFaviconUrl(url: string): string {
+  try {
+    const domain = new URL(url).hostname
+    return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`
+  } catch {
+    return ''
+  }
+}
+
 const entityTypeColors: Record<string, string> = {
   person: 'bg-blue-500/15 text-blue-400 border-blue-500/25',
   concept: 'bg-violet-500/15 text-violet-400 border-violet-500/25',
@@ -101,6 +113,7 @@ export default function NodeFeed() {
   const selectedNode = nodes.find((n) => n.id === selectedNodeId) ?? null
 
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
   const [, startTransition] = useTransition()
 
   const nodeEntities = (nodeId: string) => entities.filter((e) => e.node_id === nodeId)
@@ -183,7 +196,7 @@ export default function NodeFeed() {
               return (
                 <Card
                   key={node.id}
-                  className="group cursor-pointer border-border/50 bg-card/50 backdrop-blur-sm hover:border-primary/30 hover:bg-card/80 transition-all duration-300 hover:shadow-lg hover:shadow-primary/5"
+                  className="group cursor-pointer border-border/50 bg-card/50 backdrop-blur-sm hover:border-primary/30 hover:bg-card/80 transition-all duration-300 hover:shadow-lg hover:shadow-[oklch(0.637_0.237_275/12%)]"
                   onClick={() => setSelectedNodeId(node.id)}
                 >
                   <CardHeader className="pb-2">
@@ -193,15 +206,31 @@ export default function NodeFeed() {
                           {node.title}
                         </CardTitle>
                         <CardDescription className="mt-1.5 flex items-center gap-1.5 text-xs">
-                          <ExternalLink className="h-3 w-3 shrink-0" />
+                          {getFaviconUrl(node.url) && (
+                            <img
+                              src={getFaviconUrl(node.url)}
+                              alt=""
+                              width={14}
+                              height={14}
+                              className="shrink-0 rounded-sm"
+                              loading="lazy"
+                            />
+                          )}
                           <span className="truncate">{getDomain(node.url)}</span>
                         </CardDescription>
                       </div>
                       <div className="flex items-center gap-2 shrink-0">
-                        <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                          <Clock className="h-3 w-3" />
-                          {formatRelativeTime(node.created_at)}
-                        </span>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="flex items-center gap-1 text-xs text-muted-foreground cursor-default">
+                              <Clock className="h-3 w-3" />
+                              {formatRelativeTime(node.created_at)}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="text-xs">
+                            {formatDate(node.created_at)}
+                          </TooltipContent>
+                        </Tooltip>
                         <Button
                           variant="ghost"
                           size="icon"
@@ -220,15 +249,35 @@ export default function NodeFeed() {
                     </div>
                   </CardHeader>
                   <CardContent className="pb-3">
-                    <p className="text-sm text-muted-foreground line-clamp-2 leading-relaxed">
-                      {node.summary}
-                    </p>
+                    <div>
+                      <p className={`text-sm text-muted-foreground leading-relaxed ${
+                        expandedId === node.id ? '' : 'line-clamp-2'
+                      }`}>
+                        {node.summary}
+                      </p>
+                      {node.summary && node.summary.length > 120 && (
+                        <button
+                          type="button"
+                          className="mt-1 flex items-center gap-0.5 text-xs text-primary hover:text-primary/80 transition-colors"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setExpandedId(expandedId === node.id ? null : node.id)
+                          }}
+                        >
+                          {expandedId === node.id ? (
+                            <><ChevronUp className="h-3 w-3" /> Show less</>
+                          ) : (
+                            <><ChevronDown className="h-3 w-3" /> Read more</>
+                          )}
+                        </button>
+                      )}
+                    </div>
                     <div className="mt-3 flex items-center gap-2 flex-wrap">
                       {ne.slice(0, 3).map((entity) => (
                         <Badge
                           key={entity.id}
-                          variant="secondary"
-                          className="text-xs px-2 py-0.5 bg-primary/10 text-primary border-primary/20"
+                          variant="outline"
+                          className={`text-xs px-2 py-0.5 ${getEntityColor(entity.type)}`}
                         >
                           <Tag className="h-2.5 w-2.5 mr-1" />
                           {entity.name}
@@ -238,8 +287,9 @@ export default function NodeFeed() {
                         <span className="text-xs text-muted-foreground">+{ne.length - 3} more</span>
                       )}
                       {cc > 0 && (
-                        <span className="text-xs text-muted-foreground ml-auto">
-                          {cc} {cc === 1 ? 'link' : 'links'}
+                        <span className="flex items-center gap-1 text-xs text-muted-foreground ml-auto">
+                          <Network className="h-3 w-3" />
+                          {cc}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
## Problem

The dashboard lacks key metrics at a glance (Closes #22) and node cards need visual polish with favicons, better summaries, and color-coded entities (Closes #21). Both are p1-high tasks from [Epic #6 — Dashboard UI/UX Overhaul](https://github.com/MAX-786/project-nexus/issues/6).

## Solution

### Dashboard Stats Header (#22)
- New DashboardStats client component with 4 metric cards: **Nodes Captured**, **Entities Extracted**, **Connections**, **Due for Review**
- Each card has a unique gradient icon container matching the Nexus brand palette
- Responsive grid: 2-col on mobile, 4-col on desktop
- Stagger animation on mount using existing stagger-children CSS utility
- Due review count fetched server-side in the layout to avoid extra client queries

### Node Card Redesign (#21)
- **Favicons** via Google Favicon API next to domain name
- **Tooltip on relative time** showing the full formatted date on hover
- **Read more / Show less** toggle for summaries longer than 120 characters
- **Entity-type coloring** on badges (person=blue, concept=violet, tool=emerald, etc.)
- **Network icon** with count badge for connections (replaces plain text)
- **Nexus brand purple glow** on card hover

## Testing
1. Run `pnpm dev` and open `/dashboard/feed`
2. Verify stats bar appears between header and content (4 cards, responsive)
3. Verify node cards show favicons, colored badges, Network icon, and purple hover glow
4. Hover over relative time to see tooltip
5. Click 'Read more' on a long summary to verify expansion

## Screenshots
> UI changes — please verify visually after checkout.