### PR TITLE
feat(web): add global command palette search with Cmd+K shortcut

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.575.0",
     "next": "16.1.6",
     "next-themes": "^0.4.6",

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import NavTab from '@/components/dashboard/nav-tab'
 import AuthProvider from '@/components/providers/auth-provider'
 import DashboardStats from '@/components/dashboard/dashboard-stats'
+import CommandSearch from '@/components/dashboard/command-search'
 
 export default async function DashboardLayout({
   children,
@@ -62,6 +63,9 @@ export default async function DashboardLayout({
               <NavTab href="/dashboard/graph" icon={<Network className="h-4 w-4" />} label="Graph" />
               <NavTab href="/dashboard/review" icon={<GraduationCap className="h-4 w-4" />} label="Review" />
             </nav>
+
+            {/* Global Search — Cmd+K command palette */}
+            <CommandSearch />
 
             {/* User Section */}
             <div className="flex items-center gap-3">

--- a/apps/web/src/components/dashboard/command-search.tsx
+++ b/apps/web/src/components/dashboard/command-search.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import { FileText, Search, Tag } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command'
+import { useNodesStore } from '@/stores/nodes-store'
+import { useUIStore } from '@/stores/ui-store'
+
+// ---- Helpers ----
+
+function getDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace('www.', '')
+  } catch {
+    return url
+  }
+}
+
+function getFaviconUrl(url: string): string {
+  try {
+    const domain = new URL(url).hostname
+    return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`
+  } catch {
+    return ''
+  }
+}
+
+/** Wraps matching substrings in <mark> tags for highlight */
+function HighlightMatch({ text, query }: { text: string; query: string }) {
+  if (!query.trim()) return <>{text}</>
+
+  const lowerText = text.toLowerCase()
+  const lowerQuery = query.toLowerCase().trim()
+  const idx = lowerText.indexOf(lowerQuery)
+
+  if (idx === -1) return <>{text}</>
+
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="bg-primary/20 text-primary rounded-sm px-0.5">{text.slice(idx, idx + lowerQuery.length)}</mark>
+      {text.slice(idx + lowerQuery.length)}
+    </>
+  )
+}
+
+// ---- Component ----
+
+export default function CommandSearch() {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
+
+  const router = useRouter()
+
+  const nodes = useNodesStore((s) => s.nodes)
+  const entities = useNodesStore((s) => s.entities)
+  const setSearchQuery = useNodesStore((s) => s.setSearchQuery)
+  const setSelectedNodeId = useUIStore((s) => s.setSelectedNodeId)
+
+  // Global keyboard shortcut: Cmd+K / Ctrl+K
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        setOpen((prev) => !prev)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
+  // Reset query when dialog closes
+  const handleOpenChange = useCallback((isOpen: boolean) => {
+    setOpen(isOpen)
+    if (!isOpen) {
+      setQuery('')
+    }
+  }, [])
+
+  // Debounced filtering
+  const handleQueryChange = useCallback((value: string) => {
+    setQuery(value)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setSearchQuery(value)
+    }, 300)
+  }, [setSearchQuery])
+
+  // Cleanup debounce timer
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [])
+
+  // Filtered nodes
+  const filteredNodes = useMemo(() => {
+    const q = query.toLowerCase().trim()
+    if (!q) return nodes.slice(0, 8) // Show recent nodes when no query
+
+    return nodes.filter((node) => {
+      if (node.title.toLowerCase().includes(q)) return true
+      if (node.summary?.toLowerCase().includes(q)) return true
+      const nodeEntities = entities.filter((e) => e.node_id === node.id)
+      return nodeEntities.some((e) => e.name.toLowerCase().includes(q))
+    })
+  }, [query, nodes, entities])
+
+  // Matching entities (unique by name)
+  const matchingEntities = useMemo(() => {
+    const q = query.toLowerCase().trim()
+    if (!q) return []
+
+    const seen = new Set<string>()
+    return entities
+      .filter((e) => {
+        if (seen.has(e.name.toLowerCase())) return false
+        if (e.name.toLowerCase().includes(q)) {
+          seen.add(e.name.toLowerCase())
+          return true
+        }
+        return false
+      })
+      .slice(0, 5)
+  }, [query, entities])
+
+  // Handle selecting a node
+  function handleSelectNode(nodeId: string) {
+    setOpen(false)
+    setSearchQuery('')
+    setSelectedNodeId(nodeId)
+    router.push('/dashboard/feed')
+  }
+
+  // Handle selecting an entity — sets search query to entity name
+  function handleSelectEntity(entityName: string) {
+    setOpen(false)
+    setSearchQuery(entityName)
+    router.push('/dashboard/feed')
+  }
+
+  return (
+    <>
+      {/* Trigger Button */}
+      <button
+        type="button"
+        id="command-search-trigger"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 rounded-lg border border-border/50 bg-muted/50 px-3 py-1.5 text-sm text-muted-foreground transition-all duration-200 hover:bg-muted hover:border-border hover:text-foreground min-w-[200px]"
+      >
+        <Search className="h-3.5 w-3.5 shrink-0" />
+        <span className="flex-1 text-left">Search…</span>
+        <kbd className="pointer-events-none hidden h-5 select-none items-center gap-0.5 rounded border border-border/80 bg-background/80 px-1.5 font-mono text-[10px] font-medium text-muted-foreground sm:inline-flex">
+          <span className="text-xs">⌘</span>K
+        </kbd>
+      </button>
+
+      {/* Command Palette Dialog */}
+      <CommandDialog
+        open={open}
+        onOpenChange={handleOpenChange}
+        title="Search Knowledge Base"
+        description="Search across your captured nodes, entities, and summaries"
+        showCloseButton={false}
+      >
+        <CommandInput
+          placeholder="Search nodes, entities, summaries…"
+          value={query}
+          onValueChange={handleQueryChange}
+        />
+        <CommandList>
+          <CommandEmpty>
+            <div className="flex flex-col items-center gap-2 py-4">
+              <Search className="h-8 w-8 text-muted-foreground/50" />
+              <p className="text-muted-foreground">
+                No results found for &quot;{query}&quot;
+              </p>
+            </div>
+          </CommandEmpty>
+
+          {/* Nodes Group */}
+          {filteredNodes.length > 0 && (
+            <CommandGroup heading="Nodes">
+              {filteredNodes.slice(0, 8).map((node) => (
+                <CommandItem
+                  key={node.id}
+                  value={`node-${node.id}-${node.title}`}
+                  onSelect={() => handleSelectNode(node.id)}
+                  className="flex items-center gap-3 py-2.5"
+                >
+                  {getFaviconUrl(node.url) ? (
+                    <img
+                      src={getFaviconUrl(node.url)}
+                      alt=""
+                      width={16}
+                      height={16}
+                      className="shrink-0 rounded-sm"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="truncate text-sm font-medium">
+                      <HighlightMatch text={node.title} query={query} />
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {getDomain(node.url)}
+                      {node.summary && ` · ${node.summary.slice(0, 60)}…`}
+                    </p>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+
+          {/* Entities Group */}
+          {matchingEntities.length > 0 && (
+            <>
+              <CommandSeparator />
+              <CommandGroup heading="Entities">
+                {matchingEntities.map((entity) => (
+                  <CommandItem
+                    key={entity.id}
+                    value={`entity-${entity.id}-${entity.name}`}
+                    onSelect={() => handleSelectEntity(entity.name)}
+                    className="flex items-center gap-3 py-2"
+                  >
+                    <Tag className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div className="flex-1 min-w-0">
+                      <p className="truncate text-sm">
+                        <HighlightMatch text={entity.name} query={query} />
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground capitalize">
+                        {entity.type}
+                      </p>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </>
+          )}
+        </CommandList>
+
+        {/* Footer hint */}
+        <div className="border-t border-border/50 px-3 py-2 text-xs text-muted-foreground flex items-center gap-4">
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border border-border/80 bg-background/80 px-1 py-0.5 text-[10px] font-mono">↵</kbd>
+            select
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border border-border/80 bg-background/80 px-1 py-0.5 text-[10px] font-mono">↑↓</kbd>
+            navigate
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="rounded border border-border/80 bg-background/80 px-1 py-0.5 text-[10px] font-mono">esc</kbd>
+            close
+          </span>
+        </div>
+      </CommandDialog>
+    </>
+  )
+}

--- a/apps/web/src/components/dashboard/node-feed.tsx
+++ b/apps/web/src/components/dashboard/node-feed.tsx
@@ -103,7 +103,6 @@ export default function NodeFeed() {
   const entities = useNodesStore((s) => s.entities)
   const edges = useNodesStore((s) => s.edges)
   const searchQuery = useNodesStore((s) => s.searchQuery)
-  const setSearchQuery = useNodesStore((s) => s.setSearchQuery)
   const removeNodeFromStore = useNodesStore((s) => s.removeNode)
 
   const selectedNodeId = useUIStore((s) => s.selectedNodeId)
@@ -153,8 +152,8 @@ export default function NodeFeed() {
 
   return (
     <>
-      {/* Feed header + search */}
-      <div className="px-6 py-4 border-b border-border/50 shrink-0 space-y-3">
+      {/* Feed header */}
+      <div className="px-6 py-4 border-b border-border/50 shrink-0">
         <div className="flex items-center justify-between">
           <div>
             <div className="flex items-center gap-2">
@@ -166,17 +165,6 @@ export default function NodeFeed() {
               {searchQuery && ` · ${filteredNodes.length} matching`}
             </p>
           </div>
-        </div>
-
-        {/* Search Bar */}
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <input
-            className="flex h-9 w-full rounded-lg border border-border/50 bg-background/50 pl-9 pr-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:border-primary/50 transition-colors"
-            placeholder="Search by title, summary, or entity…"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
         </div>
       </div>
 

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@19.2.3)
@@ -3510,6 +3513,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -10186,6 +10195,18 @@ snapshots:
   clone@2.1.2: {}
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
 


### PR DESCRIPTION
Closes #20.

**Problem:** 
The search functionality was previously limited to an inline text input within the Feed tab. This restricted usability and navigation across the dashboard.

**Solution:**
- Implemented a new global CommandSearch component using Shadcn Command (cmdk).
- Added a Cmd+K / Ctrl+K keyboard shortcut that opens the command palette from anywhere in the /dashboard.
- Integrated search across nodes and extracted entities, with debounced text filtering and substring highlights.
- Removed the old inline search input from 
ode-feed.tsx.

**Testing:**
1. Navigate to any tab in the dashboard (e.g., Graph or Review).
2. Press \Ctrl+K\ (Windows) or \Cmd+K\ (Mac) or click the Search pill in the header.
3. Observe the dialog opens. Start typing to filter captured nodes.
4. Use arrow keys + Enter to navigate, or click a result to jump directly to the selected node.