### PR TITLE
feat(backend): implement semantic vector search API route

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "react-dom": "19.2.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -1,0 +1,67 @@
+import { createClient } from "@/utils/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+// Input validation schema according to nexus-supabase-db rules
+const searchSchema = z.object({
+  query_embedding: z.array(z.number()).length(1536).optional(),
+  search_term: z.string().optional(),
+  limit: z.number().min(1).max(50).default(10)
+}).refine(data => data.query_embedding !== undefined || data.search_term !== undefined, {
+  message: "Either query_embedding or search_term must be provided"
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    // Validate request body
+    const body = await request.json();
+    const parsed = searchSchema.safeParse(body);
+    
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request payload", details: parsed.error.format() }, { status: 400 });
+    }
+    
+    const { query_embedding, search_term, limit } = parsed.data;
+
+    // Verify Authorization
+    const supabase = await createClient();
+    const { data: { session }, error: authError } = await supabase.auth.getSession();
+
+    if (authError || !session) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    // Execute Database Transaction
+    let result;
+    
+    // If only keyword search without semantic embedding
+    if (!query_embedding && search_term) {
+      result = await supabase
+        .from('nodes')
+        .select('id, title, url, summary')
+        .or(`title.ilike.%${search_term}%,summary.ilike.%${search_term}%`)
+        .order('created_at', { ascending: false })
+        .limit(limit);
+    } 
+    // Handle semantic vector and hybrid search via our newly created RPC function
+    else {
+      result = await supabase.rpc('search_nodes_hybrid', {
+        query_embedding: query_embedding ? `[${query_embedding.join(',')}]` : null, // Convert array to pgvector string format
+        search_term: search_term || null,
+        match_count: limit
+      });
+    }
+
+    if (result.error) {
+      console.error("[Nexus] Supabase search error:", result.error);
+      return NextResponse.json({ error: "Search failed" }, { status: 500 });
+    }
+
+    // Return Standardized Response
+    return NextResponse.json({ results: result.data });
+
+  } catch (error) {
+    console.error("[Nexus] Search API Error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))

--- a/supabase/migrations/20240306232702_search_nodes_hybrid.sql
+++ b/supabase/migrations/20240306232702_search_nodes_hybrid.sql
@@ -1,0 +1,47 @@
+-- Function to search nodes using semantic similarity and/or keyword search
+CREATE OR REPLACE FUNCTION public.search_nodes_hybrid(
+  query_embedding vector(1536) DEFAULT NULL,
+  search_term text DEFAULT NULL,
+  match_count int DEFAULT 10
+)
+RETURNS TABLE (
+  id uuid,
+  title text,
+  url text,
+  summary text,
+  similarity float
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    nodes.id,
+    nodes.title,
+    nodes.url,
+    nodes.summary,
+    -- Calculate cosine similarity if an embedding is provided, otherwise return 1.0 (exact match) or 0.0
+    CASE 
+      WHEN query_embedding IS NOT NULL THEN 1 - (nodes.embedding <=> query_embedding)
+      ELSE 0.0::float
+    END AS similarity
+  FROM public.nodes
+  WHERE
+    -- Enforce RLS directly in case SECURITY DEFINER was used, though we use INVOKER here.
+    -- nodes.user_id = auth.uid() is handled automatically by RLS if the query runs as the authenticated user
+    nodes.user_id = auth.uid()
+    AND (
+      -- If both are provided, it must match the text OR we'll rank by vector similarity
+      -- For simplicity, if search_term is provided, we filter by it.
+      search_term IS NULL OR nodes.title ILIKE '%' || search_term || '%' OR nodes.summary ILIKE '%' || search_term || '%'
+    )
+  ORDER BY
+    -- Order by text match first if only searching by text, otherwise by semantic similarity
+    CASE 
+      WHEN query_embedding IS NOT NULL THEN (nodes.embedding <=> query_embedding)
+      ELSE 0::float -- Default ordering if only text search
+    END ASC
+  LIMIT match_count;
+END;
+$$;


### PR DESCRIPTION
### Problem
Closes #32. We need an API route for semantic vector search combined with keyword filtering, but must adhere to BYOK privacy rules.

### Solution
Added a Supabase migration search_nodes_hybrid to perform vector cosine distance calculations combined with ILIKE search. Created the /api/search route that validates inputs using Zod, expects the client to provide the pre-calculated embedding array, and handles Supabase RLS securely.

### Testing
1. Ran pnpm build to verify Next.js compiles successfully with the new Zod dependency.
2. Verified the DB migration conforms to the existing 
odes schema.