### PR TITLE
feat(extension): add capture history UI and Alt+Shift+C shortcut

### DIFF
--- a/apps/extension/background.ts
+++ b/apps/extension/background.ts
@@ -212,6 +212,24 @@ async function processCapture(result: CaptureResult, sendResponse: (res: any) =>
     }
 
     console.log("[Nexus] ✓ Capture complete!")
+
+    // Save to history
+    try {
+      const history = (await storage.get<any[]>("capture-history")) || []
+      const newEntry = {
+        id: nodeId,
+        title: result.title,
+        url: result.url,
+        summary: object.summary,
+        timestamp: Date.now()
+      }
+      history.unshift(newEntry)
+      if (history.length > 10) history.pop() // Keep last 10 captures
+      await storage.set("capture-history", history)
+    } catch (err) {
+      console.error("[Nexus] Failed to save history:", err)
+    }
+
     sendResponse({ success: true, summary: object.summary })
 
   } catch (err: any) {
@@ -240,5 +258,23 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "process_capture" && message.payload) {
     processCapture(message.payload, sendResponse)
     return true // async response
+  }
+})
+
+// Listen for keyboard commands
+chrome.commands.onCommand.addListener((command) => {
+  if (command === "capture_page") {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const activeTab = tabs[0]
+      if (activeTab?.id) {
+        chrome.tabs.sendMessage(activeTab.id, { action: "capture_from_popup" }, (response) => {
+          if (chrome.runtime.lastError) {
+            console.error("[Nexus] capture shortcut error:", chrome.runtime.lastError)
+          } else {
+            console.log("[Nexus] capture initiated from shortcut.")
+          }
+        })
+      }
+    })
   }
 })

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -40,6 +40,15 @@
   "manifest": {
     "host_permissions": [
       "https://*/*"
-    ]
+    ],
+    "commands": {
+      "capture_page": {
+        "suggested_key": {
+          "default": "Alt+Shift+C",
+          "mac": "Command+Shift+C"
+        },
+        "description": "Capture the current page to Project Nexus"
+      }
+    }
   }
 }

--- a/apps/extension/popup.tsx
+++ b/apps/extension/popup.tsx
@@ -16,6 +16,16 @@ function IndexPopup() {
   const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null)
   const [captureCount, setCaptureCount] = useState(0)
   const [jwtStatus, setJwtStatus] = useState<"valid" | "expiring_soon" | "expired">("valid")
+  const [history, setHistory] = useState<any[]>([])
+
+  // Load history
+  const loadHistory = async () => {
+    const hist = await storage.get<any[]>("capture-history")
+    if (hist) setHistory(hist)
+  }
+  useEffect(() => {
+    loadHistory()
+  }, [])
 
   // Check JWT Status
   useEffect(() => {
@@ -115,6 +125,7 @@ function IndexPopup() {
           setStatus("done")
           setToast({ message: `Captured: ${tabs[0]!.title?.substring(0, 50) || "Page"}`, type: "success" })
           incrementCaptureCount()
+          loadHistory()
           setTimeout(() => setToast(null), 3000)
         } else {
           setStatus("error")
@@ -238,6 +249,34 @@ function IndexPopup() {
             )}
             {statusLabel[status]}
           </button>
+
+          {/* Capture History */}
+          {history.length > 0 && (
+            <div className="mt-4 border-t border-nexus-border pt-3">
+              <div className="flex justify-between items-center mb-2 px-1">
+                <span className="text-xs font-semibold text-nexus-muted">Recent Captures</span>
+                <button
+                  onClick={async () => {
+                    await storage.remove("capture-history")
+                    setHistory([])
+                  }}
+                  className="text-[10px] text-nexus-muted hover:text-nexus-error transition-colors"
+                >
+                  Clear
+                </button>
+              </div>
+              <ul className="space-y-2 max-h-48 overflow-y-auto pr-1">
+                {history.map((item, idx) => (
+                  <li key={item.id || idx} className="bg-nexus-border/20 p-2.5 rounded-lg border border-nexus-border/50 hover:bg-nexus-border/40 transition-colors">
+                    <a href={item.url} target="_blank" rel="noreferrer" className="block outline-none">
+                      <h4 className="text-xs font-medium text-white mb-1 truncate">{item.title}</h4>
+                      <p className="text-[10px] text-nexus-muted line-clamp-2 leading-tight">{item.summary}</p>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
         
         {/* Toast Container */}


### PR DESCRIPTION
### Problem
Closes #29 and Closes #31. We needed to display recent captures within the extension popup, and we needed a global keyboard shortcut to capture pages without opening the popup.

### Solution
- Added capture_page command shortcut (Alt+Shift+C) to package.json manifest.
- Updated ackground.ts to listen for the shortcut and trigger the capture logic via the active tab's content script.
- Updated ackground.ts to persist the 10 most recent captures into local storage.
- Updated popup.tsx to display the 'Recent Captures' list, complete with URLs and truncating the summaries, including a button to clear history.

### Testing
1. Built the extension with pnpm build and ensured no TypeScript/React errors.
2. The keyboard listener uses chrome.commands api which correctly triggers the content extraction.